### PR TITLE
[ACR] Get ACR specific AAD token in token exchange

### DIFF
--- a/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
+++ b/src/azure-cli/azure/cli/command_modules/acr/_docker_utils.py
@@ -126,7 +126,8 @@ def _get_aad_token_after_challenge(cli_ctx,
 
     # this might be a cross tenant scenario, so pass subscription to get_raw_token
     subscription = get_subscription_id(cli_ctx)
-    creds, _, tenant = profile.get_raw_token(subscription=subscription)
+    resource = "https://containerregistry.azure.net"
+    creds, _, tenant = profile.get_raw_token(subscription=subscription, resource=resource)
 
     headers = {'Content-Type': 'application/x-www-form-urlencoded'}
     content = {


### PR DESCRIPTION
**Description**<!--Mandatory-->
Getting an aad token specifically for the ACR resource is required to support scenario when data plane resources have enhanced authentication than ARM resources, For example ACR needs MFA but ARM does not.

**Testing Guide**
az login
az acr login -n registryName

**History Notes**
<!--If your PR is not customer-facing, use {Component Name} in the PR title. Otherwise, use [Component Name] to allow our pipeline to add the title as a history note. If you need multiple history notes or would like to overwrite the note from the PR title, please fill in the following templates.-->

[Component Name 1] BREAKING CHANGE: az command a: Make some customer-facing breaking change.
[Component Name 2] az command b: Add some customer-facing feature.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] The PR title and description has followed the guideline in [Submitting Pull Requests](https://github.com/Azure/azure-cli/tree/dev/doc/authoring_command_modules#submitting-pull-requests).

- [ ] I adhere to the [Command Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/command_guidelines.md).

- [ ] I adhere to the [Error Handling Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/error_handling_guidelines.md).
